### PR TITLE
EventBus instead of AsyncTasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,36 @@
-# Teleport - Data Sync & Messaging Library for Android Wear
+# Teleport (Android Wear sync lib) + EventBus
 
 ![Screen](/doc/images/teleport_256.png)
 
-Teleport is a library to easily setup and manage Data Syncronization and Messaging on Android Wearables.
+**This is a modified version of Teleport, it uses EventBus to propagate Messages or DataItems across Services/Activities instead of AsyncTasks**
 
-*The library is thought for Android Studio.*
+I really encourage you to check both original lib and this to see which one fits your needs best.
 
+So use is the same as Teleport but receiving is done a bit differently.
 
+Firstly you need a Service that extends `WearableListenerService` to receive changes, if you want some custom/background handling of events, override methods `onDataChanged()` or `onMessageReceived()` - remember to call in those `EventBus.getDefault().post(content);` as otherwise bus will be **not** notified.
 
-##Quick Overview
+In your Wear Activity it is dead easy if you work with EventBus any time before that - even if not it is still easy.
 
-You can see Teleport as an Android Wear "plugin" you can add to your Activities and Services.
+Just registered `onStart()` and unregister in `onStop()` with default bus:
+'EventBus.getDefault().register(this);'
 
-Teleport provides you **commodity classes** to easily establish a communication between a mobile handheld device and an Android Wear device.
+and to receive messages implement method:
+`public void onEvent(final String event) {//do your magic here}`
 
-*  `TeleportClient` provides you "endpoints" you can put inside your Activities, both in Mobile and Wear.
-*  `TeleportService` is a full-fledged, already set-up 'WearableListenerService'. 
+to receive DataItems just use:
+`public void onEvent(DataMap dataMap) {//get object etc. }`
 
-Both these classes incapsulates all the `GoogleApiClient` setup required to establish a connection between Mobile and Wear.
+Simple as that!
 
-`TeleportClient` and `TeleportService` also provide you two `AsyncTask` you can extend to easily perform operations with the synced DataItems and received Messages:
+Michał Tajchert
+If you have any idea what to change just poke me:
+[Google+](https://plus.google.com/+MichalTajchert/)
 
-* `OnSyncDataItemTask` provides you a complete `DataMap` of synced data
-* `OnGetMessageTask` provides you access to a received Message `path` in form of `String`.
+I don't thing it is stuff to pull request, so (for now) it is quite separate and we will see what to do next - **merge or not to merge?**
 
-You just need to *extend* these tasks inside your Activity/Service and you're good to go!
+Original author of Teleport:
 
-To Sync Data and send Messages, you can use commodity methods like
-
-* `sync<ItemType>(String key, <ItemType> item)` to Sync Data across devices
-* `sendMessage(String path, byte[] payload)` to send a Message to another device.
-
-##Summary
-
-* [Library Set Up:](/doc/SETUP.md) How to import Teleport library in your project.
-* [TeleportClient in Activity:](/doc/TELEPORTCLIENT.md) How to setup a TeleportClient.
-* [TeleportService:](/doc/TELEPORTSERVICE.md) How to setup a TeleportService.
-* [Sync Data:](/doc/SYNCDATA.md) How to Sync Data
-* [Send and Receive Messages:](/doc/MESSAGE.md) How to Send and Receive Messages
-* [Advanced Usage:](/doc/ADVANCEDUSAGE.md) AsyncTask Factory and Callbacks
-
-##Can I have an example of how easy is Teleport to use?
-
-There you go :-) 
-
-Here's a *Mobile and a Wear Activity* already configured to Sync Data. 
-
-* The MobileActivity synchronizes a string "Hello, World!".
-* The WearActivity shows a Toast with the synchronized string.
-
-###MobileActivity.java   
-```java
-    
-    public class MobileActivity extends Activity {
-
-    TeleportClient mTeleportClient;
-    
-        @Override
-        protected void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            setContentView(R.layout.activity_mobile);
-
-             mTeleportClient = new TeleportClient(this);         
-         }
-
-        @Override
-        protected void onStart() {
-            super.onStart();
-            mTeleportClient.connect();
-            }
-
-        @Override
-        protected void onStop() {
-            super.onStop();
-            mTeleportClient.disconnect();
-         }
-    
-  
-        public void syncDataItem(View v) {                   
-           //Let's sync a String!
-           mTeleportClient.syncString("hello", "Hello, World!");   
-        }
-        
-    }
-```
-    
-###WearActivity.java
-    
-```java
-
-    public class WearActivity extends Activity {
-    
-        TeleportClient mTeleportClient;
-        
-        @Override
-        protected void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            setContentView(R.layout.activity_wear);
-    
-             mTeleportClient = new TeleportClient(this);
-             
-             mTeleportClient.setOnSyncDataItemTask(new ShowToastHelloWorldTask());
-             
-        }
-    
-        @Override
-        protected void onStart() {
-            super.onStart();
-            mTeleportClient.connect();
-        }
-    
-        @Override
-        protected void onStop() {
-            super.onStop();
-            mTeleportClient.disconnect();
-    
-        }
-    
-        public class ShowToastHelloWorldTask extends TeleportClient.OnSyncDataItemTask {
-        
-                @Override
-                protected void onPostExecute(DataMap dataMap) {
-        
-                    String hello = dataMap.getString("hello");   
-        
-                    Toast.makeText(getApplicationContext(),hello,Toast.LENGTH_SHORT).show();
-                }
-        }
-            
-    }
-```
-    
-Jump to [Library Set Up](/doc/SETUP.md) !!!
-
-##Follow me on
 Author: Mario Viviani
 <a href="https://plus.google.com/+MarioViviani/posts">
   <img alt="Follow me on Google+"
@@ -165,6 +62,5 @@ Teleport is released under the **Apache License 2.0**
         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
         See the License for the specific language governing permissions and
         limitations under the License.
-
 
 

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -29,6 +29,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     wearApp project(':wear')
+    compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.google.android.gms:play-services-wearable:+'
     compile project(':teleportlib')
 }

--- a/mobile/src/main/java/com/mariux/teleport/MobileActivity.java
+++ b/mobile/src/main/java/com/mariux/teleport/MobileActivity.java
@@ -11,6 +11,8 @@ import android.widget.Toast;
 import com.google.android.gms.wearable.DataMap;
 import com.mariux.teleport.lib.TeleportClient;
 
+import de.greenrobot.event.EventBus;
+
 
 public class MobileActivity extends Activity {
 
@@ -30,30 +32,18 @@ public class MobileActivity extends Activity {
 
     }
 
-//    @Override
-//    protected void onResume() {
-//        super.onResume();
-//        mTeleportClient.connect();
-//    }
-//
-//    @Override
-//    protected void onPause() {
-//        super.onPause();
-//        mTeleportClient.disconnect();
-//
-//    }
-
     @Override
     protected void onStart() {
         super.onStart();
         mTeleportClient.connect();
+        EventBus.getDefault().register(this);
     }
 
     @Override
     protected void onStop() {
         super.onStop();
         mTeleportClient.disconnect();
-
+        EventBus.getDefault().unregister(this);
     }
 
     @Override
@@ -77,57 +67,37 @@ public class MobileActivity extends Activity {
 
     public void syncDataItem(View v) {
 
-        //set the AsyncTask to execute when the Data is Synced
-        mTeleportClient.setOnSyncDataItemTask(new ShowToastOnSyncDataItemTask());
-
-        //Let's sync a String!
-        mTeleportClient.syncString("string", syncDataItemEditText.getText().toString());
-
+        //Let's sync a Custom Object - how cool is that?
+        mTeleportClient.syncString("sting", syncDataItemEditText.getText().toString());
     }
 
     public void sendMessage(View v) {
-
-        mTeleportClient.setOnGetMessageTask(new ShowToastFromOnGetMessageTask());
-
         mTeleportClient.sendMessage(sendMessageEditText.getText().toString(), null);
     }
 
     public void sendStartActivityMessage(View v) {
-
-        mTeleportClient.setOnGetMessageTask(new ShowToastFromOnGetMessageTask());
-
         mTeleportClient.sendMessage("startActivity", null);
     }
+    
+    //For DataItem API changes
+    public void onEvent(DataMap dataMap) {
+        final String s = dataMap.getString("string");
 
-
-    public class ShowToastOnSyncDataItemTask extends TeleportClient.OnSyncDataItemTask {
-
-        @Override
-        protected void onPostExecute(DataMap dataMap) {
-
-            String s = dataMap.getString("string");
-
-
-            Toast.makeText(getApplicationContext(),"DataItem - "+s,Toast.LENGTH_SHORT).show();
-
-            //let's reset the task (otherwise it will be executed only once)
-            mTeleportClient.setOnSyncDataItemTask(new ShowToastOnSyncDataItemTask());
-        }
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(getApplicationContext(),"DataItem - "+s,Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
-
-    public class ShowToastFromOnGetMessageTask extends TeleportClient.OnGetMessageTask {
-
-        @Override
-        protected void onPostExecute(String path) {
-
-
-            Toast.makeText(getApplicationContext(),"Message - "+path,Toast.LENGTH_SHORT).show();
-
-            //let's reset the task (otherwise it will be executed only once)
-            mTeleportClient.setOnGetMessageTask(new ShowToastFromOnGetMessageTask());
-        }
+    //For Message API receiving
+    public void onEvent(final String path) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(getApplicationContext(), "Message - " + path, Toast.LENGTH_SHORT).show();
+            }
+        });
     }
-
-
 }

--- a/teleportlib/build.gradle
+++ b/teleportlib/build.gradle
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.google.android.gms:play-services-wearable:+'
 }
 

--- a/teleportlib/src/main/java/com/mariux/teleport/lib/TeleportService.java
+++ b/teleportlib/src/main/java/com/mariux/teleport/lib/TeleportService.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
+import de.greenrobot.event.EventBus;
+
 /**
  * Created by Mario Viviani on 10/07/2014.
  */
@@ -35,15 +37,6 @@ public abstract class TeleportService extends WearableListenerService{
 
     private GoogleApiClient mGoogleApiClient;
     private static final String TAG = "TeleportService";
-
-
-    //    private AsyncTask<?,?,?> asyncTask;
-    private OnSyncDataItemTask onSyncDataItemTask;
-    private OnSyncDataItemTask.Builder onSyncDataItemTaskBuilder;
-    private OnSyncDataItemCallback onSyncDataItemCallback;
-    private OnGetMessageTask onGetMessageTask;
-    private OnGetMessageTask.Builder onGetMessageTaskBuilder;
-    private OnGetMessageCallback onGetMessageCallback;
 
     @Override
     public void onCreate() {
@@ -56,8 +49,6 @@ public abstract class TeleportService extends WearableListenerService{
 
     }
 
-
-
     //--------------SYNC DATAITEM ------------------//
 
     @Override
@@ -68,24 +59,10 @@ public abstract class TeleportService extends WearableListenerService{
         for (DataEvent event : events) {
             if (event.getType() == DataEvent.TYPE_CHANGED) {
 
-
-
                 DataMapItem dataMapItem = DataMapItem.fromDataItem(event.getDataItem());
                 DataMap dataMap = dataMapItem.getDataMap();
 
-                boolean flagHandled = false;
-                if (onSyncDataItemTaskBuilder != null) {
-                    onSyncDataItemTaskBuilder.build().execute(dataMap);
-                    flagHandled = true;
-                }
-                if (!flagHandled && onSyncDataItemCallback != null) {
-                    onSyncDataItemCallback.onDataSync(dataMap);
-                    flagHandled = true;
-                }
-                if (!flagHandled && onSyncDataItemTask != null) {
-                    onSyncDataItemTask.execute(dataMap);
-                    flagHandled = true;
-                }
+                EventBus.getDefault().post(dataMap);
 
             } else if (event.getType() == DataEvent.TYPE_DELETED) {
                 Log.d("DataItem Deleted", event.getDataItem().toString());
@@ -167,72 +144,6 @@ public abstract class TeleportService extends WearableListenerService{
                 });
     }
 
-    /**
-     * Get the TeleportTask that will be executed when a DataItem is synced
-     *
-     */
-    public OnSyncDataItemTask getOnSyncDataItemTask() {
-        return onSyncDataItemTask;
-    }
-
-
-    /**
-     * Set the TeleportTask to be executed when a DataItem is synced
-     *
-     * @param onSyncDataItemTask task to be executed. Keep in mind it will be executed only once, so you might need to reset it.
-     */
-    public void setOnSyncDataItemTask(OnSyncDataItemTask onSyncDataItemTask) {
-        this.onSyncDataItemTask = onSyncDataItemTask;
-    }
-
-
-
-
-    public abstract static class OnSyncDataItemTask extends AsyncTask<DataMap, Void, DataMap> {
-
-        public abstract static class Builder {
-
-            public abstract OnSyncDataItemTask build();
-
-        }
-
-        protected DataMap doInBackground(DataMap... param) {
-
-            //DataMap dataMap = DataMap.fromByteArray((byte[]) param[0]);
-
-            return param[0];
-
-            //return param[0];
-        }
-
-        protected abstract void onPostExecute(DataMap result);
-    }
-
-    public abstract static class OnSyncDataItemCallback {
-
-        abstract public void onDataSync(DataMap dataMap);
-    }
-
-    /**
-     * Set a Builder to be called in order to have an AsyncTask Handling the DataItem syncing
-     * Keep in mind that you shall not use this unless you have multiple Syncing event coming in a short timelapse, thus requiring multiple AsyncTask to handle them.
-     *
-     * @param onSyncDataItemTaskBuilder A Builder for a task that extends TeleportTask that should be executed when a DataItem is Synced. Keep in mind it will be executed only once, so you might need to reset it.
-     */
-    public void setOnSyncDataItemTaskBuilder(OnSyncDataItemTask.Builder onSyncDataItemTaskBuilder) {
-        this.onSyncDataItemTaskBuilder = onSyncDataItemTaskBuilder;
-    }
-
-    /**
-     * Set the Callback to be executed when a DataItem is synced
-     *
-     * @param onSyncDataItemCallback A Task that extends TeleportTask that should be executed when a DataItem is Synced. Keep in mind it will be executed only once, so you might need to reset it.
-     */
-    public void setOnSyncDataItemCallback(OnSyncDataItemCallback onSyncDataItemCallback) {
-        this.onSyncDataItemCallback = onSyncDataItemCallback;
-    }
-
-
     //-----------------MESSAGING------------------//
 
     private Collection<String> getNodes() {
@@ -246,7 +157,6 @@ public abstract class TeleportService extends WearableListenerService{
 
         return results;
     }
-
 
     //Task to send messages to nodes
     private class StartTeleportMessageTask extends AsyncTask<Object, Void, Object> {
@@ -290,76 +200,7 @@ public abstract class TeleportService extends WearableListenerService{
     public void onMessageReceived(MessageEvent messageEvent) {
         Log.d(TAG, "onMessageReceived() A message from watch was received:" + messageEvent.getRequestId() + " " + messageEvent.getPath());
 
-        boolean flagHandled = false;
-
-        if(onGetMessageTaskBuilder != null) {
-            String path = messageEvent.getPath();
-            onGetMessageTaskBuilder.build().execute(path);
-            flagHandled = true;
-        }
-
-        if(!flagHandled && onGetMessageCallback != null) {
-            String messagePath = messageEvent.getPath();
-            onGetMessageCallback.onCallback(messagePath);
-            flagHandled = true;
-        }
-
-        if (!flagHandled && onGetMessageTask != null) {
-            String messagePath = messageEvent.getPath();
-            onGetMessageTask.execute(messagePath);
-            flagHandled = true;
-        }
-
-    }
-
-    /**
-     * AsyncTask that will be executed when a Message is received You should extend this task and implement the onPostExecute() method when implementing your Service.
-     *
-     * */
-    public abstract static class OnGetMessageTask extends AsyncTask<String, Void, String> {
-
-        public abstract static class Builder {
-
-            public abstract OnGetMessageTask build();
-
-        }
-
-        protected String doInBackground(String... path) {
-
-            return path[0];
-
-
-        }
-
-        protected abstract void onPostExecute(String path);
-    }
-
-    public abstract static class OnGetMessageCallback {
-
-        abstract public void onCallback(String dataMap);
-    }
-
-
-    public OnGetMessageTask getOnGetMessageTask() {
-        return onGetMessageTask;
-    }
-
-    public void setOnGetMessageTask(OnGetMessageTask onGetMessageTask) {
-        this.onGetMessageTask = onGetMessageTask;
-    }
-
-    /**
-     * Set a Builder to be called in order to have an AsyncTask Handling Message
-     * Keep in mind that you shall not use this unless you have multiple Message event coming in a short timelapse, thus requiring multiple AsyncTask to handle them.
-     *
-     * @param onGetMessageTaskBuilder A Builder for a task that extends TeleportTask that should be executed when a DataItem is Synced. Keep in mind it will be executed only once, so you might need to reset it.
-     */
-    public void setOnGetMessageTaskBuilder(OnGetMessageTask.Builder onGetMessageTaskBuilder) {
-        this.onGetMessageTaskBuilder = onGetMessageTaskBuilder;
-    }
-
-    public void setOnGetMessageCallback(OnGetMessageCallback onGetMessageCallback) {
-        this.onGetMessageCallback = onGetMessageCallback;
+        EventBus.getDefault().post(messageEvent.getPath());
     }
 
     /***
@@ -381,29 +222,6 @@ public abstract class TeleportService extends WearableListenerService{
 
     };
 
-//    /**
-//     * Loads Bitmap from Asset
-//     *
-//     * @param asset Asset to be converted to Bitmap
-//     */
-//    public Bitmap loadBitmapFromAsset(Asset asset) {
-//        if (asset == null) {
-//            throw new IllegalArgumentException("Asset must be non-null");
-//        }
-//
-//        // convert asset into a file descriptor and block until it's ready
-//        InputStream assetInputStream = Wearable.DataApi.getFdForAsset(
-//                mGoogleApiClient, asset).await().getInputStream();
-//
-//
-//        if (assetInputStream == null) {
-//            Log.w(TAG, "Requested an unknown Asset.");
-//            return null;
-//        }
-//        // decode the stream into a bitmap
-//        return BitmapFactory.decodeStream(assetInputStream);
-//    }
-
     public GoogleApiClient getGoogleApiClient() {
         return mGoogleApiClient;
     }
@@ -411,7 +229,4 @@ public abstract class TeleportService extends WearableListenerService{
     public void setGoogleApiClient(GoogleApiClient mGoogleApiClient) {
         this.mGoogleApiClient = mGoogleApiClient;
     }
-
-
-
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -28,6 +28,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.google.android.support:wearable:+'
     compile 'com.google.android.gms:play-services-wearable:+'
     compile project(':teleportlib')

--- a/wear/src/main/java/com/mariux/teleport/WearService.java
+++ b/wear/src/main/java/com/mariux/teleport/WearService.java
@@ -1,67 +1,37 @@
 package com.mariux.teleport;
 
-import android.content.Context;
 import android.content.Intent;
-import android.widget.Toast;
+import android.util.Log;
 
-import com.mariux.teleport.lib.TeleportClient;
+import com.google.android.gms.wearable.MessageEvent;
 import com.mariux.teleport.lib.TeleportService;
+
+import de.greenrobot.event.EventBus;
 
 /**
  * Created by Mario on 10/07/2014.
  */
 public class WearService extends TeleportService{
-
-
+    private static final String TAG = "WearService";
 
     @Override
     public void onCreate() {
         super.onCreate();
-
-        //The quick way is to use setOnGetMessageTask, and set a new task
-        setOnGetMessageTask(new StartActivityTask());
-
-
-        //alternatively, you can use the Builder to create new Tasks
-        /*
-        setOnGetMessageTaskBuilder(new OnGetMessageTask.Builder() {
-            @Override
-            public OnGetMessageTask build() {
-                return new OnGetMessageTask() {
-                    @Override
-                    protected void onPostExecute(String path) {
-                        if (path.equals("startActivity")){
-
-                            Intent startIntent = new Intent(getBaseContext(), WearActivity.class);
-                            startIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                            startActivity(startIntent);
-                        }
-
-                    }
-                };
-            }
-        });
-        */
-
     }
 
-    //Task that shows the path of a received message
-    public class StartActivityTask extends TeleportService.OnGetMessageTask {
 
-        @Override
-        protected void onPostExecute(String  path) {
+    //If we want to react to changes in background we need to implement onMessageReceived or onDataChanged plus post() for eventBus
+    @Override
+    public void onMessageReceived(MessageEvent messageEvent) {
+        //Notify potential other subcribers as you just overtake over message receiving
+        EventBus.getDefault().post(messageEvent.getPath());
 
-       if (path.equals("startActivity")){
-
+        //Our custom part
+        Log.d(TAG, "onMessageReceived in Service : " + messageEvent);
+        if (messageEvent.getPath().equals("startActivity")) {
             Intent startIntent = new Intent(getBaseContext(), WearActivity.class);
             startIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(startIntent);
-         }
-
-            //let's reset the task (otherwise it will be executed only once)
-            setOnGetMessageTask(new StartActivityTask());
         }
     }
-
-
 }


### PR DESCRIPTION
I replaced AsyncTaks with EventBus ( :bus: ) that allows to achieve same results with 30% less code in library and 30% less code in the sample, and (for me at least) it is way more clear/easy to work.

I have also updated README file to describe EventBus - it is not ready to be merged (it was done for fork), so README file for sure needs to be changed, or use branch "bus" which does include old README file.

Please lets use that thread to discuss disadvantages of such solution, as I may be missing something. Also I do understand the point that such change is radical and will make all code not supporting newer versions of Teleport without some change.
